### PR TITLE
WLS license

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -5,9 +5,8 @@ name: Python application
 
 on:
   push:
-    branches: [ main, renaming]
-  pull_request:
-    branches: [ main, renaming]
+    branches: main
+  pull_request_target:
 
 permissions:
   contents: read
@@ -37,12 +36,14 @@ jobs:
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - shell: bash
+      id: write-license
       env:
-        WLSACCESSID : ${{ secrets.WLSACCESSID }}
-        WLSSECRET   : ${{ secrets.WLSSECRET   }}
-        LICENSEID   : ${{ secrets.LICENSEID   }}
+        LICENSE: ${{ secrets.LICENSE   }}
       run: |
-        echo "$LICENSEID"
+        echo "$LICENSE" > $PWD/gurobi.lic
+        echo "::set-output name=grb_license_file::$PWD/gurobi.lic"
     - name: Test with tox
+      env:
+        GRB_LICENSE_FILE: ${{ steps.write-license.outputs.grb_license_file }}
       run: |
         tox

--- a/tox.ini
+++ b/tox.ini
@@ -34,14 +34,11 @@ commands =
     ipython --matplotlib pdf {toxinidir}/examples/Functions_approx/"2DPeakFunction Pytorch.py"
     ipython --matplotlib pdf {toxinidir}/examples/Functions_approx/Parabola.py
     ipython --matplotlib pdf {toxinidir}/examples/Functions_approx/ParabolaPyTorch.py
+    ipython --matplotlib pdf {toxinidir}/examples/Functions_approx/ParabolaTree.py
 
 [testenv]
 passenv =
-    WLSSECRET
-    LICENSEID
-    WLSACCESSID
-    GURO_PAR_SPECIAL
-    WLS_VARIABLES
+    GRB_LICENSE_FILE
 deps =
     pytest
     numpy


### PR DESCRIPTION
This is a PoC with an example that requires a license. It is going through now.

Any comments?

And then I'd like to replace the current 3 secrets with a single secret that encompasses `gurobi.lic` so that I can do:
```
    - shell: bash
      id: write-license
      env:
        LICENSE   : ${{ secrets.LICENSE   }}
      run: |
        echo "$LICENSE" > $PWD/gurobi.lic
        echo "::set-output name=grb_license_file::$PWD/gurobi.lic"
```
Since I cannot see the content of the current secrets, could you create this new secret, combining them according to the file content according this PR?