### PR TITLE
Fix some inconsistencies with column_transformer and get_convertor

### DIFF
--- a/src/gurobi_ml/add_predictor.py
+++ b/src/gurobi_ml/add_predictor.py
@@ -15,7 +15,6 @@
 
 """Define generic function that can add any known trained predictor."""
 
-from .exceptions import NotRegistered
 from .modeling.get_convertor import get_convertor
 from .registered_predictors import registered_predictors
 
@@ -76,6 +75,4 @@ def add_predictor_constr(gp_model, predictor, input_vars, output_vars=None, **kw
     """
     convertors = registered_predictors()
     convertor = get_convertor(predictor, convertors)
-    if convertor is None:
-        raise NotRegistered(type(predictor).__name__)
     return convertor(gp_model, predictor, input_vars, output_vars, **kwargs)

--- a/src/gurobi_ml/modeling/get_convertor.py
+++ b/src/gurobi_ml/modeling/get_convertor.py
@@ -15,6 +15,8 @@
 
 """Utility function to find function that add a predictor in dictionnary."""
 
+from ..exceptions import NotRegistered
+
 
 def get_convertor(predictor, convertors):
     """Return the convertor for a given predictor."""
@@ -23,17 +25,19 @@ def get_convertor(predictor, convertors):
         convertor = convertors[type(predictor)]
     except KeyError:
         pass
-    if convertor is None:
+    if not convertor:
         for parent in type(predictor).mro():
             try:
                 convertor = convertors[parent]
                 break
             except KeyError:
                 pass
-    if convertor is None:
+    if not convertor:
         name = type(predictor).__name__
         try:
             convertor = convertors[name]
         except KeyError:
             pass
+    if not convertor:
+        raise NotRegistered(type(predictor).__name__)
     return convertor

--- a/src/gurobi_ml/sklearn/column_transformer.py
+++ b/src/gurobi_ml/sklearn/column_transformer.py
@@ -20,7 +20,7 @@ import warnings
 import gurobipy as gp
 from sklearn.preprocessing import FunctionTransformer
 
-from ..exceptions import NoModel
+from ..modeling.get_convertor import get_convertor
 from .preprocessing import sklearn_transformers
 from .skgetter import SKtransformer
 
@@ -125,10 +125,9 @@ class ColumnTransformerConstr(SKtransformer):
                         data = data[:, cols]
                         any_var = True
                 if any_var:
-                    try:
-                        trans_constr = transformers[name](self.gp_model, trans, data)
-                    except KeyError:
-                        raise NoModel(name, "No implementation found")
+                    trans_constr = get_convertor(trans, sklearn_transformers())(
+                        self.gp_model, trans, data
+                    )
                     transformed.append(trans_constr.output.tolist())
                 else:
                     transformed.append(trans.transform(_input.loc[:, cols]))

--- a/src/gurobi_ml/sklearn/pipeline.py
+++ b/src/gurobi_ml/sklearn/pipeline.py
@@ -18,7 +18,6 @@ in a :gurobipy:`model`.
 """
 
 
-from ..exceptions import NoModel
 from ..modeling.base_predictor_constr import AbstractPredictorConstr
 from ..modeling.get_convertor import get_convertor
 from ..register_user_predictor import user_predictors
@@ -107,11 +106,6 @@ class PipelineConstr(SKgetter, AbstractPredictorConstr):
 
         for transformer in pipeline[:-1]:
             convertor = get_convertor(transformer, transformers)
-            if convertor is None:
-                raise NoModel(
-                    self.predictor,
-                    f"I don't know how to deal with that object: {transformer}",
-                )
             steps.append(convertor(gp_model, transformer, input_vars, **kwargs))
             input_vars = steps[-1].output
 
@@ -119,11 +113,6 @@ class PipelineConstr(SKgetter, AbstractPredictorConstr):
         predictors = sklearn_predictors() | user_predictors()
         predictors |= xgboost_sklearn_convertors()
         convertor = get_convertor(predictor, predictors)
-        if convertor is None:
-            raise NoModel(
-                self.predictor,
-                f"I don't know how to deal with that object: {predictor}",
-            )
         steps.append(convertor(gp_model, predictor, input_vars, output_vars, **kwargs))
         if self._output is None:
             self._output = steps[-1].output

--- a/tests/test_pandas/test_pandas_exceptions.py
+++ b/tests/test_pandas/test_pandas_exceptions.py
@@ -12,7 +12,7 @@ from sklearn.pipeline import make_pipeline
 from sklearn.preprocessing import FunctionTransformer, StandardScaler
 
 from gurobi_ml import add_predictor_constr
-from gurobi_ml.exceptions import NoModel
+from gurobi_ml.exceptions import NotRegistered
 
 
 class TestUnsuportedPandas(unittest.TestCase):
@@ -47,7 +47,7 @@ class TestUnsuportedPandas(unittest.TestCase):
 
         x = self.create_input(m, example)
 
-        with self.assertRaises(NoModel):
+        with self.assertRaises(NotRegistered):
             add_predictor_constr(m, mlpreg, x)
 
     def test_pipeline_fail_transformer_str(self):
@@ -71,5 +71,5 @@ class TestUnsuportedPandas(unittest.TestCase):
 
         x = self.create_input(m, example)
 
-        with self.assertRaises(NoModel):
+        with self.assertRaises(NotRegistered):
             add_predictor_constr(m, mlpreg, x)

--- a/tests/test_sklearn/test_column_transformer.py
+++ b/tests/test_sklearn/test_column_transformer.py
@@ -11,7 +11,7 @@ from sklearn.pipeline import make_pipeline
 from sklearn.preprocessing import FunctionTransformer, StandardScaler
 
 from gurobi_ml import add_predictor_constr
-from gurobi_ml.exceptions import NoModel
+from gurobi_ml.exceptions import NotRegistered
 
 
 class TestColumnTransformer(unittest.TestCase):
@@ -84,5 +84,5 @@ class TestColumnTransformer(unittest.TestCase):
 
         x = m.addMVar(example.shape)
 
-        with self.assertRaises(NoModel):
+        with self.assertRaises(NotRegistered):
             add_predictor_constr(m, mlpreg, x)

--- a/tests/test_sklearn/test_sklearn_exceptions.py
+++ b/tests/test_sklearn/test_sklearn_exceptions.py
@@ -11,7 +11,7 @@ from sklearn.preprocessing import PolynomialFeatures, QuantileTransformer
 from sklearn.svm import LinearSVR
 
 from gurobi_ml import add_predictor_constr
-from gurobi_ml.exceptions import NoModel, ParameterError
+from gurobi_ml.exceptions import NoModel, NotRegistered, ParameterError
 
 
 class TestUnsuportedSklearn(unittest.TestCase):
@@ -88,7 +88,7 @@ class TestUnsuportedSklearn(unittest.TestCase):
 
         x = m.addMVar(example.shape, name="x")
 
-        with self.assertRaises(NoModel):
+        with self.assertRaises(NotRegistered):
             add_predictor_constr(m, mlpreg, x)
 
     def test_polynomial_feature_degree3(self):
@@ -124,5 +124,5 @@ class TestUnsuportedSklearn(unittest.TestCase):
 
         x = m.addMVar(example.shape, name="x")
 
-        with self.assertRaises(NoModel):
+        with self.assertRaises(NotRegistered):
             add_predictor_constr(m, mlpreg, x)


### PR DESCRIPTION
In column_transformer, was not using get_convertor to get the function to transform the columns.

Was also raising the wrong exception "NoModel" instead of "NotRegistered".

There are other places.