### PR TITLE
Update tox.ini to include macOS libomp install instructions

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,8 @@
 # in multiple virtualenvs. This configuration file will run the
 # test suite on all supported python versions. To use it, "pip install tox"
 # and then run "tox" from this directory.
+# Users running macOS may need to install libomp.  If using the Homebrew 
+# package manager then this can be achieved with "brew install libomp".
 
 [tox]
 envlist = {py39,py310,py311,py312}-{lightgbm,keras,pandas,pytorch,sklearn,xgboost,no_deps,all_deps}-{gurobi10,gurobi11},pre-commit,docs,examples-{gurobi10,gurobi11}

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 # in multiple virtualenvs. This configuration file will run the
 # test suite on all supported python versions. To use it, "pip install tox"
 # and then run "tox" from this directory.
-# Users running macOS may need to install libomp.  If using the Homebrew 
+# Users running macOS may need to install libomp.  If using the Homebrew
 # package manager then this can be achieved with "brew install libomp".
 
 [tox]


### PR DESCRIPTION
Added to the comment at top of the file:
\# Users running macOS may need to install libomp.  If using the Homebrew 
\# package manager then this can be achieved with "brew install libomp".

I'm not sure if similar guidance is needed for Windows and Linux users.