### PR TITLE
[GH316] Avoid logistic function for classification with Logistic Regression

### DIFF
--- a/src/gurobi_ml/sklearn/logistic_regression.py
+++ b/src/gurobi_ml/sklearn/logistic_regression.py
@@ -43,16 +43,16 @@ def add_logistic_regression_constr(
     The formulation predicts the values of output_vars using input_vars according to
     logistic_regression.
 
-    When the desired output type is classification the result can be achieved without
-    appealing to the logistic function, and consequently non-linearity can be avoided.
-    When the desired output type is regression then the (non-linear) logistic function
-    is required. For users of Gurobi ≥ 11.0, the attribute FuncNonlinear is set to 1 to
-    deal directly with the logistic function in an algorithmic fashion.
+    When the desired output type is classification a mixed integer linear formulation
+    using indicator constraints is used. When the desired output type is regression
+    then the (non-linear) logistic function is required. For users of Gurobi ≥ 11.0,
+    the attribute FuncNonlinear is set to 1 to deal directly with the logistic
+    function in an algorithmic fashion.
 
     For older versions, Gurobi makes a piecewise linear approximation of the logistic
     function.
     The quality of the approximation can be controlled with the parameter
-    pwl_attributes. By default, it is parameterized so that the maximal error of the
+    pwl_attributes. By default, it is parametrized so that the maximal error of the
     approximation is `1e-2`.
 
     See our :ref:`Users Guide <Logistic Regression>` for

--- a/tests/test_sklearn/test_sklearn_formulations.py
+++ b/tests/test_sklearn/test_sklearn_formulations.py
@@ -116,7 +116,7 @@ class TestSklearnModel(FixedRegressionModel):
                 X,
                 5,
                 "all",
-                output_type="classification",
+                output_type="probability_1",
                 pwl_attributes={"FuncPieces": 5},
             )
 


### PR DESCRIPTION
Addresses #316 

A few things I hadn't initially anticipated:
- MVars in indicator constraints don't work with v10.  I've put in a function to workaround this.  At some point I assume we will stop supporting v10, at which point this workaround can be removed.
- epsilon parameter needs to be translated from range of logistic function to the domain, via the inverse of the function
- the docstrings and warnings needed to be massaged to not mislead users regarding PWL attributes when using classification