### PR TITLE
Make GH action tests lighter

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ python =
     3.9: py39-all_deps-gurobi11
     3.10: py310-all_deps-gurobi11
     3.12: py312-all_deps-gurobi11
-    3.11: pre-commit, docs,py311-{lightgbm,keras,pytorch,sklearn,xgboost,no_deps,all_deps}-{gurobi10,gurobi11}
+    3.11: pre-commit, docs,py311-{lightgbm,keras,pytorch,sklearn,xgboost,no_deps,pandas}-{gurobi10,gurobi11}
 
 [testenv:docs]
 deps=


### PR DESCRIPTION
Don't do the all_deps test when we do all the individual one with different venvs.