### PR TITLE
Cleanup tox env dir after test

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ python =
     3.9: py39-all_deps-gurobi11
     3.10: py310-all_deps-gurobi11
     3.12: py312-all_deps-gurobi11
-    3.11: pre-commit, docs,py311-{lightgbm,keras,pytorch,sklearn,xgboost,no_deps,pandas}-{gurobi10,gurobi11}
+    3.11: pre-commit, docs,py311-{lightgbm,keras,pytorch,sklearn,xgboost,no_deps,all_deps}-{gurobi10,gurobi11}
 
 [testenv:docs]
 deps=

--- a/toxfile.py
+++ b/toxfile.py
@@ -1,6 +1,8 @@
 import shutil
+
 from tox.plugin import impl
 from tox.tox_env.api import ToxEnv
+
 
 @impl
 def tox_env_teardown(tox_env: ToxEnv):

--- a/toxfile.py
+++ b/toxfile.py
@@ -1,0 +1,8 @@
+import shutil
+from tox.plugin import impl
+from tox.tox_env.api import ToxEnv
+
+@impl
+def tox_env_teardown(tox_env: ToxEnv):
+    print(f"removing env dir: {tox_env}")
+    shutil.rmtree(tox_env.env_dir)


### PR DESCRIPTION
Closes #332.

This magic file installs a tox hook that runs after a target has finished.

We should be able to revert https://github.com/Gurobi/gurobi-machinelearning/commit/86d911c274d160911f57011d1320dd0c06bb500b with this.